### PR TITLE
Make multi-version compatible, use modern parsers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "wdl"]
+	path = wdl
+	url = https://github.com/openwdl/wdl

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,14 @@ setup(name="wdl2cwl",
       author='Peter Amstutz, Anton Khodak',
       author_email='anton.khodak@ukr.net',
       url='https://github.com/common-workflow-language/wdl2cwl',
-      install_requires=['future', 'jinja2', 'wdl>=1.1.0'],
+      install_requires=[
+          'future',
+          'jinja2',
+          'wdl-parser'
+      ],
       packages=find_packages(),
       package_data={'wdl2cwl': ['templates/*', 'expression-tools/*']},
       include_package_data=True,
-      dependency_links=['http://github.com/anton-khodak/pywdl/tarball/master#egg=wdl-1.1.0'],
       entry_points={
           'console_scripts': [
               'wdl2cwl=wdl2cwl.main:main'

--- a/wdl2cwl/main.py
+++ b/wdl2cwl/main.py
@@ -131,11 +131,6 @@ def handleTask(item, **kwargs):
 
 def handleInputDeclaration(item, **kwargs):
     return handleDeclaration(item, **kwargs)
-    # def handleInputs(item, **kwargs):
-    #     for m in pick_symbol(item, "map", "inputs"):
-    #         ihandle(m, **kwargs)
-    #
-    # pass
 
 
 def handleWorkflow(item, **kwargs):


### PR DESCRIPTION
Hi all, I've been interested in getting this working for newer WDL versions (e.g. draft-3 aka 1.0), as well as providing a path forward after the demise of pyWdl. By doing that we also get the ability to make this package `pip` installable, since it won't depend on the pyWdl fork it currently uses.

To this end, I've created and published a package for the WDL parsers in python (https://github.com/TMiguelT/WdlParserPackaging), and I've started integrating it into your existing code.

**I'm not finished**, so please don't accept this PR just yet, but I'm somewhat stuck on fixing up the current node visit rules, and I was wondering if any of you original devs think you could help me make it compatible with both draft-2 and draft-3 (there weren't a whole lot of changes to be honest).